### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -1,6 +1,6 @@
 var cluster = require("cluster"),
     _ = require("underscore"),
-    uuid = require("node-uuid"),
+    uuid = require("uuid"),
     C = require("./constants"),
     debug = require('debug')('lpm:supervisor'),
     utils = require('./utilities'),

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -4,7 +4,7 @@ var service = {},
     util = require('./utilities'),
     debug = require('debug')('lpm:worker'),
     _ = require('underscore'),
-    uuid = require("node-uuid"),
+    uuid = require("uuid"),
     through2 = require('through2'),
     net = require('net'),
     parentPID;

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "node-uuid": "^1.4.7",
     "q": "^1.4.1",
     "through2": "^2.0.1",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "uuid": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.